### PR TITLE
Feature/#29 community post write UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'; // BrowserRouter를 import
 import HomePage from './pages/Home/HomePage';
 import MainLayout from './layouts/MainLayout';
 import TestPostCard from './pages/TestPostCard';
 import PostDetail from './components/community/PostDetail';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'; // BrowserRouter를 import
+import PostWrite from './pages/Community/PostWrite';
 import LoginPage from './pages/Login/LoginPage';
 import SignupPage from './pages/Signup/SignupPage';
 import FindPasswordPage from './pages/FindPassword/FindPasswordPage';
@@ -33,10 +33,26 @@ function App() {
           }
         />
         <Route path="/login" element={<LoginPage />} />
-        <Route path='/signup' element={<SignupPage />} />
-        <Route path='/find-password' element={<FindPasswordPage />} />
-        <Route path='/change-password' element={<ChangePasswordPage />} />
-        <Route path='/community-test' element={<TestPostCard />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/find-password" element={<FindPasswordPage />} />
+        <Route path="/change-password" element={<ChangePasswordPage />} />
+        <Route
+          path="/community-test"
+          element={
+            <MainLayout>
+              <TestPostCard />{' '}
+            </MainLayout>
+          }
+        />
+
+        <Route
+          path="/community/write"
+          element={
+            <MainLayout>
+              <PostWrite />
+            </MainLayout>
+          }
+        />
       </Routes>
     </Router>
   );

--- a/src/components/community/CommunityTitle.tsx
+++ b/src/components/community/CommunityTitle.tsx
@@ -1,0 +1,9 @@
+interface CommunityTitleProps {
+  title: string;
+}
+
+const CommunityTitle = ({ title }: CommunityTitleProps) => {
+  return <h2 className="text-[30px] font-bold text-[#091033] mb-4">{title}</h2>;
+};
+
+export default CommunityTitle;

--- a/src/components/community/MoreDropdown.tsx
+++ b/src/components/community/MoreDropdown.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import IconWrapper from './IconWrapper';
-import { Ellipsis, EllipsisVertical } from 'lucide-react';
+import { EllipsisVertical } from 'lucide-react';
 
 interface MenuItem {
   label: string;
@@ -13,7 +13,7 @@ interface MoreDropdownProps {
   menuItems: MenuItem[];
   hasIcon?: boolean;
   align?: 'left' | 'right';
-  type?: 'comment' | 'post'; // 버튼 구분용
+  type?: 'comment' | 'post';
 }
 
 const MoreDropdown = ({ menuItems, hasIcon = true, align = 'right', type = 'post' }: MoreDropdownProps) => {
@@ -30,19 +30,23 @@ const MoreDropdown = ({ menuItems, hasIcon = true, align = 'right', type = 'post
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const trigger =
+    type === 'comment' ? (
+      <span className="text-gray-600 text-[18px] leading-none">⋯</span>
+    ) : (
+      <IconWrapper icon={EllipsisVertical} size={20} color="#9ca3af" />
+    );
+
   return (
     <div className="relative inline-block text-left" ref={dropdownRef}>
-      <button
+      <div
         onClick={() => setIsOpen(!isOpen)}
-        className="p-1 rounded-md hover:bg-gray-100 transition"
+        role="button"
         aria-label="더보기"
+        className="p-1 rounded-md hover:bg-gray-100 transition cursor-pointer"
       >
-        {type === 'comment' ? (
-          <span className="text-gray-600 text-[18px] leading-none">⋯</span>
-        ) : (
-          <IconWrapper icon={EllipsisVertical} size={20} color="#9ca3af" />
-        )}
-      </button>
+        {trigger}
+      </div>
 
       {isOpen && (
         <div

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -6,7 +6,6 @@ import AuthorInfo from './AuthorInfo';
 import LikeButton from './LikeButton';
 import CommentButton from './CommentButton';
 import IconWrapper from './IconWrapper';
-
 interface ExtendedProps extends PostCardProps {
   onLikeToggle?: () => void;
   onCommentClick?: () => void;
@@ -25,8 +24,8 @@ const PostCard = ({ post, onLikeToggle, onCommentClick }: ExtendedProps) => {
   const formattedDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
 
   return (
-    <div onClick={handleCardClick} className="w-full max-w-[800px] mx-auto px-4 sm:px-6 py-8 cursor-pointer">
-      <div className="border bg-white rounded-lg p-[30px] shadow-sm">
+    <div onClick={handleCardClick} className="w-full mx-auto cursor-pointer">
+      <div className="border bg-white rounded-lg p-[30px] shadow-sm mb-7">
         {/* 작성자/작성일 */}
         <div className="flex items-center justify-between mb-5">
           <div className="flex items-center gap-2">

--- a/src/components/community/PostDetail.tsx
+++ b/src/components/community/PostDetail.tsx
@@ -8,6 +8,7 @@ import CommentButton from './CommentButton';
 import IconWrapper from './IconWrapper';
 import CommentList from './CommentList';
 import PostMoreButton from './PostMoreButton';
+import CommunityTitle from './CommunityTitle';
 
 const PostDetail = () => {
   const { id } = useParams();
@@ -27,57 +28,52 @@ const PostDetail = () => {
   };
 
   return (
-    <div className="w-full max-w-[800px] mx-auto px-4 sm:px-6 py-8">
-      <div className="border bg-white rounded-lg shadow-sm">
-        <div className="p-[30px]">
-          {/* 작성자/작성일/더보기 */}
-          <div className="flex items-center justify-between mb-5">
-            <div className="flex items-center gap-2">
-              <AuthorInfo author={author} />
-              <span className="text-xs text-primary-500 ml-2">{formattedDate}</span>
-            </div>
-            {isMine && (
-              <div className="relative">
-                <PostMoreButton onEdit={handleEdit} onDelete={handleDelete} />
-              </div>
-            )}
+    <div className="w-full max-w-[800px] mx-auto px-4 sm:px-6">
+      <CommunityTitle title="감정 소비 이야기" />
+
+      <div className="border bg-white rounded-lg p-[30px] shadow-sm">
+        {/* 작성자/작성일/더보기 */}
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <AuthorInfo author={author} />
+            <span className="text-xs text-primary-500 ml-2">{formattedDate}</span>
           </div>
-
-          {/* 제목 */}
-          <h2 className="text-xl font-semibold text-gray-800 mb-3">{title}</h2>
-
-          {/* 이미지 */}
-          {imageUrl && (
-            <div className="relative flex items-center justify-center w-full bg-gray-200 rounded mb-6 h-auto sm:h-[400px]">
-              <img src={imageUrl} alt="게시물 이미지" className="w-full sm:w-auto h-auto sm:h-full object-cover" />
+          {isMine && (
+            <div className="relative">
+              <PostMoreButton onEdit={handleEdit} onDelete={handleDelete} />
             </div>
           )}
-
-          {/* 내용 */}
-          <p className="text-gray-700 mb-6 whitespace-pre-line">{content}</p>
-
-          {/* 좋아요/댓글/조회수 */}
-          <div className="flex items-center justify-between text-gray-400 text-xs mt-4">
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-1">
-                <LikeButton size={14} onToggle={() => console.log('좋아요')} />
-                <span className="text-primary-500">{likes}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <CommentButton size={14} onClick={() => console.log('댓글')} />
-                <span className="text-primary-500">{comments}</span>
-              </div>
+        </div>
+        {/* 제목 */}
+        <h2 className="text-xl font-semibold text-gray-800 mb-3">{title}</h2>
+        {/* 이미지 */}
+        {imageUrl && (
+          <div className="relative flex items-center justify-center w-full bg-gray-200 rounded mb-6 h-auto sm:h-[400px]">
+            <img src={imageUrl} alt="게시물 이미지" className="w-full sm:w-auto h-auto sm:h-full object-cover" />
+          </div>
+        )}
+        {/* 내용 */}
+        <p className="text-gray-700 mb-6 whitespace-pre-line">{content}</p>
+        {/* 좋아요/댓글/조회수 */}
+        <div className="flex items-center justify-between text-gray-400 text-xs mt-4">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1">
+              <LikeButton size={14} onToggle={() => console.log('좋아요')} />
+              <span className="text-primary-500">{likes}</span>
             </div>
-            <div className="flex items-center gap-1 text-gray-400 text-xs cursor-default select-none">
-              <IconWrapper icon={Eye} size={14} className="pointer-events-none" />
-              <span className="text-primary-500">{views}</span>
+            <div className="flex items-center gap-1">
+              <CommentButton size={14} onClick={() => console.log('댓글')} />
+              <span className="text-primary-500">{comments}</span>
             </div>
           </div>
-
-          {/* 댓글 영역 */}
-          <div className="pt-4">
-            <CommentList />
+          <div className="flex items-center gap-1 text-gray-400 text-xs cursor-default select-none">
+            <IconWrapper icon={Eye} size={14} className="pointer-events-none" />
+            <span className="text-primary-500">{views}</span>
           </div>
+        </div>
+        {/* 댓글 영역 */}
+        <div className="pt-4">
+          <CommentList />
         </div>
       </div>
     </div>

--- a/src/pages/Community/PostWrite.tsx
+++ b/src/pages/Community/PostWrite.tsx
@@ -1,12 +1,28 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button';
 import CommunityTitle from '@/components/community/CommunityTitle';
 import { Image } from 'lucide-react';
+import { Post } from '@/types/Post';
 
 const PostWrite = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const existingPost = location.state as Post | undefined; // 수정 모드인지 판단
+
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [image, setImage] = useState<File | null>(null);
+
+  const isEdit = !!existingPost;
+
+  useEffect(() => {
+    if (isEdit && existingPost) {
+      setTitle(existingPost.title);
+      setContent(existingPost.content);
+      // 이미지 초기화는 제외 (API 연동 시 처리)
+    }
+  }, [isEdit, existingPost]);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -14,9 +30,14 @@ const PostWrite = () => {
   };
 
   const handleSubmit = () => {
-    const confirmed = window.confirm('게시글을 등록하시겠습니까?');
+    const confirmed = window.confirm(`게시글을 ${isEdit ? '수정' : '등록'}하시겠습니까?`);
     if (!confirmed) return;
-    // 등록 로직 추가 예정
+
+    // 등록/수정 API 로직 작성 예정
+    // ...
+
+    // 완료 후 이동
+    navigate('/community/1'); // 추후 수정 필요 (예: 등록된 postId 활용)
   };
 
   return (
@@ -50,7 +71,7 @@ const PostWrite = () => {
 
       <div className="mt-6">
         <Button width="w-full" onClick={handleSubmit}>
-          등록
+          {isEdit ? '수정' : '등록'}
         </Button>
       </div>
     </div>

--- a/src/pages/Community/PostWrite.tsx
+++ b/src/pages/Community/PostWrite.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import Button from '@/components/common/Button';
+import CommunityTitle from '@/components/community/CommunityTitle';
+import { Image } from 'lucide-react';
+
+const PostWrite = () => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [image, setImage] = useState<File | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setImage(file);
+  };
+
+  const handleSubmit = () => {
+    const confirmed = window.confirm('게시글을 등록하시겠습니까?');
+    if (!confirmed) return;
+    // 등록 로직 추가 예정
+  };
+
+  return (
+    <div className="w-full max-w-[800px] mx-auto px-4 sm:px-6 py-8">
+      <CommunityTitle title="감정 소비 이야기" />
+
+      <div className="border bg-white rounded-lg p-6 shadow-sm">
+        <input
+          type="text"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="제목을 입력해주세요."
+          className="w-full text-xl font-medium placeholder:text-gray-400 mb-4 focus:outline-none border-b pb-2"
+        />
+
+        <textarea
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder="콘텐츠 내용을 입력하세요."
+          className="w-full min-h-[200px] placeholder:text-gray-400 text-sm focus:outline-none border-b pb-4 resize-none"
+        />
+
+        <div className="flex items-center justify-between mt-4 text-sm text-gray-400 pb-3">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Image size={16} />
+            <span>사진 {image ? '1/1' : '0/1'}</span>
+            <input type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <Button width="w-full" onClick={handleSubmit}>
+          등록
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PostWrite;

--- a/src/pages/TestPostCard.tsx
+++ b/src/pages/TestPostCard.tsx
@@ -1,9 +1,11 @@
 import { dummyPosts } from '../constants/dummyPosts';
 import PostCard from '../components/community/PostCard';
+import CommunityTitle from '@/components/community/CommunityTitle';
 
 const TestPostCard = () => {
   return (
-    <div className="w-full mx-auto px-4 sm:px-6 space-y-6 py-8">
+    <div className="w-full mx-auto max-w-[800px] px-4 sm:px-6">
+      <CommunityTitle title="감정 소비 이야기" />
       {dummyPosts.map(post => (
         <PostCard
           post={post}


### PR DESCRIPTION
## 변경 사항
- 게시글 작성 페이지 UI 기본 입력 폼 구성
- 페이지 제목 공통 컴포넌트(CommunityTitle) 적용
- 게시글 등록 및 수정 모드 분기 처리
- 수정 모드 진입 시 기존 게시글 데이터를 초기값으로 세팅
- 게시글 등록/수정 완료 후 상세 페이지로 이동 처리
- 게시글 더보기 버튼 클릭 시 수정 기능 연동
- 드롭다운 버튼 내 중첩 구조 디버깅
 
### 스크린샷
- 등록
![image](https://github.com/user-attachments/assets/5652e9dd-18a2-47ed-ab1e-c127b3202471)
![image](https://github.com/user-attachments/assets/ab4823b0-dbdc-40d8-b309-e087a0f9b232)

- 수정
![image](https://github.com/user-attachments/assets/8e1dcc52-2370-4a8e-aecf-77d421fbba51)
![image](https://github.com/user-attachments/assets/6dbf09df-b436-4579-877e-d4bae263d4bd)
![image](https://github.com/user-attachments/assets/fc55e2d2-b2d3-41cc-a6c6-034298d56c00)


## 반영 브랜치
- 예: feature/login → develop

## 관련 이슈
- Closes #29  

## 참고 사항
- http://localhost:5173/community/write (접속 시 정상 렌더링 확인)