### PR TITLE
[refator] #35 DropdownInput 재사용성 향상 (스타일 분기, 플레이스홀더 속성 추가)

### DIFF
--- a/src/components/common/DropdownInput.tsx
+++ b/src/components/common/DropdownInput.tsx
@@ -4,10 +4,18 @@ import { useEffect, useRef, useState } from 'react';
 interface DropdownProps {
   items: string[];
   selected: string;
+  style: 'outline' | 'underline';
+  placeholder?: string;
   onSelect: (item: string) => void;
 }
 
-const DropdownInput = ({ items, selected, onSelect }: DropdownProps) => {
+const getWrapperClass = (style: 'outline' | 'underline') => {
+  return style === 'underline'
+    ? 'border-b-2 border-primary-800 rounded-none bg-transparent'
+    : 'border border-gray-300 rounded-md bg-white';
+};
+
+const DropdownInput = ({ items, selected, style, placeholder, onSelect }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -22,18 +30,17 @@ const DropdownInput = ({ items, selected, onSelect }: DropdownProps) => {
   }, []);
 
   return (
-    <div ref={ref} className="relative inline-block mb-4">
-      <div className="flex items-center bg-white h-[60px] w-[500px] border border-gray-300 rounded-md px-3 py-2 text-sm">
-        <span className="text-sm flex-grow text-gray-900">
-          {selected || <span className="text-gray-500">질문을 선택하세요.</span>}
-        </span>
-        <button type="button" onClick={() => setIsOpen(prev => !prev)} className="ml-2">
-          <ChevronDown />
-        </button>
+    <div ref={ref} className="relative inline-block mb-4 w-[500px]">
+      <div
+        className={`flex items-center h-[60px] px-3 py-2 text-sm cursor-pointer ${getWrapperClass(style)}`}
+        onClick={() => setIsOpen(prev => !prev)}
+      >
+        <span className={`flex-grow ${selected ? 'text-gray-900' : 'text-gray-500'}`}>{selected || placeholder}</span>
+        <ChevronDown />
       </div>
 
       {isOpen && (
-        <ul className="absolute left-0 w-[500px] border rounded bg-white shadow z-10 text-gray-600">
+        <ul className="absolute left-0 w-full border rounded bg-white shadow z-10 text-gray-600 max-h-[200px] overflow-auto">
           {items.map(item => (
             <li
               key={item}
@@ -41,7 +48,7 @@ const DropdownInput = ({ items, selected, onSelect }: DropdownProps) => {
                 onSelect(item);
                 setIsOpen(false);
               }}
-              className="border-b-[1px] px-4 py-2 hover:bg-gray-100 cursor-pointer"
+              className="border-b px-4 py-2 hover:bg-gray-100 cursor-pointer"
             >
               {item}
             </li>

--- a/src/pages/Signup/components/SecurityQuestion.tsx
+++ b/src/pages/Signup/components/SecurityQuestion.tsx
@@ -1,5 +1,5 @@
+import DropdownInput from "@/components/common/DropdownInput";
 import Input from "@/components/common/Input";
-import DropdownInput from "./DropdownInput";
 
 interface SecurityQuestionProps {
   question: string;
@@ -15,6 +15,8 @@ const SecurityQuestion = ({questions, question, answer, onChange} : SecurityQues
       <DropdownInput
         items={questions}
         selected={question}
+        style="outline"
+        placeholder="질문을 선택하세요."
         onSelect={value => onChange('question', value)}
       />
       <Input

--- a/src/pages/Signup/components/SecurityQuestion.tsx
+++ b/src/pages/Signup/components/SecurityQuestion.tsx
@@ -15,7 +15,7 @@ const SecurityQuestion = ({questions, question, answer, onChange} : SecurityQues
       <DropdownInput
         items={questions}
         selected={question}
-        style="outline"
+        style="underline"
         placeholder="질문을 선택하세요."
         onSelect={value => onChange('question', value)}
       />


### PR DESCRIPTION
## 변경 사항
- DropdownInput 공통 컴포넌트로 이동 및 코드 개선

## 반영 브랜치
- feature/#35-common/input → develop

## 관련 이슈
- close #35 

## 참고 사항
- DropdownInput 컴포넌트에 style prop 추가 ('outline' | 'underline')
- placeholder optional 처리

![image](https://github.com/user-attachments/assets/914b8de2-f74c-4637-96b0-0b4836d5ff72)
![image](https://github.com/user-attachments/assets/95f02257-1dc0-4def-92e5-116871611e82)
