### PR TITLE
Feature/#38 community list UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,9 +32,10 @@ function App() {
         <Route path="/change-password" element={<ChangePasswordPage />} />
 
         {/* 게시글 관련 페이지 */}
-        <Route path="/community/:type" element={<MainLayout><CommunityList /></MainLayout>} />
-        <Route path="/community/:id" element={<MainLayout><PostDetail /></MainLayout>} />
+        <Route path="/community/:type/:postId" element={<MainLayout><PostDetail /></MainLayout>} /> {/* 게시글 상세 먼저! */}
+        <Route path="/community/:type" element={<MainLayout><CommunityList /></MainLayout>} /> {/* 게시판 리스트 */}
         <Route path="/community/write" element={<MainLayout><PostWrite /></MainLayout>} />
+
         {/* 테스트용 페이지 (개발 완료 후 제거 예정) */}
         <Route path="/community-test" element={<MainLayout><TestPostCard /></MainLayout>} />
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SignupPage from './pages/Signup/SignupPage';
 import FindPasswordPage from './pages/FindPassword/FindPasswordPage';
 import ChangePasswordPage from './pages/ChangePassword/ChangePasswordPage';
 import MyPage from './pages/myPage/MyPage';
+import CommunityList from './pages/Community/CommunityList';
 
 function App() {
   return (
@@ -31,9 +32,9 @@ function App() {
         <Route path="/change-password" element={<ChangePasswordPage />} />
 
         {/* 게시글 관련 페이지 */}
+        <Route path="/community/:type" element={<MainLayout><CommunityList /></MainLayout>} />
         <Route path="/community/:id" element={<MainLayout><PostDetail /></MainLayout>} />
         <Route path="/community/write" element={<MainLayout><PostWrite /></MainLayout>} />
-
         {/* 테스트용 페이지 (개발 완료 후 제거 예정) */}
         <Route path="/community-test" element={<MainLayout><TestPostCard /></MainLayout>} />
       </Routes>

--- a/src/components/community/CommunityNewPostButton.tsx
+++ b/src/components/community/CommunityNewPostButton.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+import { PenLine } from 'lucide-react';
+import IconButton from '@/components/common/IconButton';
+
+interface CommunityNewPostProps {
+  to: string;
+  postType: 'emotion' | 'question' | 'notice';
+}
+
+const CommunityNewPostButton = ({ to, postType }: CommunityNewPostProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(to, { state: { type: postType } });
+  };
+
+  return (
+    <IconButton
+      icon={PenLine}
+      onClick={handleClick}
+      ariaLabel="커뮤니티 글 작성하기"
+    />
+  );
+};
+
+export default CommunityNewPostButton;

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -19,17 +19,20 @@ const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProp
   const { id, title, imageUrl, content, createdAt, likes, comments, views, author } = post;
   const formattedDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
 
-  const isInDetailPage = location.pathname.startsWith('/community/') && location.pathname !== '/community/emotion' && location.pathname !== '/community/question';
+  const isInDetailPage =
+    location.pathname.startsWith('/community/') &&
+    location.pathname !== '/community/emotion' &&
+    location.pathname !== '/community/question';
 
   const handleClick = () => {
-      if (!isInDetailPage) navigate(`/community/${post.type}/${post.id}`);
+    if (!isInDetailPage) navigate(`/community/${post.type}/${post.id}`);
   };
 
   if (viewType === 'list') {
     // 리스트 뷰
     return (
       <div
-        className="w-full bg-white rounded-lg border p-5 shadow-sm flex justify-between items-center gap-4 mb-5 cursor-pointer"
+        className="w-full bg-white rounded-lg border p-5 shadow-sm flex justify-between items-center gap-4 cursor-pointer"
         onClick={handleClick}
       >
         {/* 왼쪽 텍스트 */}
@@ -68,7 +71,7 @@ const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProp
   // 피드 뷰
   return (
     <div
-      className="w-full bg-white rounded-lg border p-5 shadow-sm flex flex-col gap-4 mb-5 cursor-pointer"
+      className="w-full bg-white rounded-lg border p-5 shadow-sm flex flex-col gap-4 cursor-pointer"
       onClick={handleClick}
     >
       {/* 작성자/작성일 */}
@@ -82,7 +85,10 @@ const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProp
 
       {/* 이미지 */}
       {imageUrl && (
-        <div className="w-full bg-gray-300 flex items-center justify-center rounded-md overflow-hidden" style={{ maxHeight: '400px' }}>
+        <div
+          className="w-full bg-gray-300 flex items-center justify-center rounded-md overflow-hidden"
+          style={{ maxHeight: '400px' }}
+        >
           <img
             src={imageUrl}
             alt="본문 이미지"

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -1,73 +1,117 @@
-import { format } from 'date-fns';
-import { PostCardProps } from '../../types/Post';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { format } from 'date-fns';
 import { Eye } from 'lucide-react';
-import AuthorInfo from './AuthorInfo';
+import { PostCardProps } from '@/types/Post';
 import LikeButton from './LikeButton';
 import CommentButton from './CommentButton';
 import IconWrapper from './IconWrapper';
+import AuthorInfo from './AuthorInfo';
+
 interface ExtendedProps extends PostCardProps {
+  viewType: 'list' | 'grid';
   onLikeToggle?: () => void;
   onCommentClick?: () => void;
 }
 
-const PostCard = ({ post, onLikeToggle, onCommentClick }: ExtendedProps) => {
+const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProps) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const isInDetailPage = location.pathname.startsWith('/community/');
-
-  const handleCardClick = () => {
-    if (!isInDetailPage) navigate(`/community/${post.id}`);
-  };
-
-  const { title, imageUrl, content, createdAt, likes, comments, views, author } = post;
+  const { id, title, imageUrl, content, createdAt, likes, comments, views, author } = post;
   const formattedDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
 
-  return (
-    <div onClick={handleCardClick} className="w-full mx-auto cursor-pointer">
-      <div className="border bg-white rounded-lg p-[30px] shadow-sm mb-7">
-        {/* 작성자/작성일 */}
-        <div className="flex items-center justify-between mb-5">
-          <div className="flex items-center gap-2">
-            <AuthorInfo author={author} />
-            <span className="text-xs text-primary-500 ml-2">{formattedDate}</span>
-          </div>
-        </div>
+  const isInDetailPage = location.pathname.startsWith('/community/') && location.pathname !== '/community/emotion' && location.pathname !== '/community/question';
 
-        {/* 제목 */}
-        <h2 className="text-xl font-semibold text-gray-800 mb-3">{title}</h2>
+  const handleClick = () => {
+    if (!isInDetailPage) navigate(`/community/${id}`);
+  };
 
-        {/* 이미지 */}
-        {imageUrl && (
-          <div className="relative flex items-center justify-center w-full bg-gray-200 rounded mb-6 h-auto sm:h-[400px]">
-            <img src={imageUrl} alt="게시물 이미지" className="w-full sm:w-auto h-auto sm:h-full object-cover" />
-          </div>
-        )}
-
-        {/* 내용 */}
-        <p className="text-gray-700 mb-6 whitespace-pre-line">{content}</p>
-
-        {/* 좋아요/댓글/조회수 (조회수는 상세에서만 노출) */}
-        <div className="flex items-center justify-between text-gray-400 text-xs mt-4">
-          <div className="flex items-center gap-4">
+  if (viewType === 'list') {
+    // 리스트 뷰
+    return (
+      <div
+        className="w-full bg-white rounded-lg border p-5 shadow-sm flex justify-between items-center gap-4 mb-5 cursor-pointer"
+        onClick={handleClick}
+      >
+        {/* 왼쪽 텍스트 */}
+        <div className="flex flex-col flex-1">
+          <AuthorInfo author={author} />
+          <h2 className="text-base font-semibold text-gray-800 mt-2 line-clamp-1">{title}</h2>
+          <p className="text-gray-600 text-sm mt-1 line-clamp-2">{content}</p>
+          <div className="flex items-center gap-6 text-primary-500 text-xs mt-3">
             <div className="flex items-center gap-1">
               <LikeButton size={14} onToggle={onLikeToggle} />
-              <span className="text-primary-500">{likes}</span>
+              <span>{likes}</span>
             </div>
             <div className="flex items-center gap-1">
               <CommentButton size={14} onClick={onCommentClick} />
-              <span className="text-primary-500">{comments}</span>
+              <span>{comments}</span>
             </div>
+            {isInDetailPage && (
+              <div className="flex items-center gap-1 ml-auto text-gray-400">
+                <IconWrapper icon={Eye} size={14} />
+                <span>{views}</span>
+              </div>
+            )}
           </div>
-          {isInDetailPage ? (
-            <div className="flex items-center gap-1 text-gray-400 text-xs cursor-default select-none">
-              <IconWrapper icon={Eye} size={14} className="pointer-events-none" />
-              <span className="text-primary-500">{views}</span>
-            </div>
-          ) : (
-            <div className="w-[40px]" />
-          )}
         </div>
+
+        {/* 오른쪽 썸네일 */}
+        {imageUrl && (
+          <div className="w-[100px] h-[100px] overflow-hidden rounded-md flex-shrink-0">
+            <img src={imageUrl} alt="썸네일" className="object-cover w-full h-full" />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // 피드 뷰
+  return (
+    <div
+      className="w-full bg-white rounded-lg border p-5 shadow-sm flex flex-col gap-4 mb-5 cursor-pointer"
+      onClick={handleClick}
+    >
+      {/* 작성자/작성일 */}
+      <div className="flex items-center gap-2">
+        <AuthorInfo author={author} />
+        <span className="text-xs text-primary-500">{formattedDate}</span>
+      </div>
+
+      {/* 제목 */}
+      <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+
+      {/* 이미지 */}
+      {imageUrl && (
+        <div className="w-full bg-gray-300 flex items-center justify-center rounded-md overflow-hidden" style={{ maxHeight: '400px' }}>
+          <img
+            src={imageUrl}
+            alt="본문 이미지"
+            className="object-contain w-full max-h-[400px]"
+          />
+        </div>
+      )}
+
+      {/* 내용 */}
+      <p className="text-gray-700 text-sm line-clamp-2">{content}</p>
+
+      {/* 좋아요/댓글/조회수 */}
+      <div className="flex items-center justify-between text-gray-400 text-xs mt-4">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1">
+            <LikeButton size={14} onToggle={onLikeToggle} />
+            <span className="text-primary-500">{likes}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <CommentButton size={14} onClick={onCommentClick} />
+            <span className="text-primary-500">{comments}</span>
+          </div>
+        </div>
+        {isInDetailPage && (
+          <div className="flex items-center gap-1 text-gray-400 cursor-default select-none">
+            <IconWrapper icon={Eye} size={14} className="pointer-events-none" />
+            <span className="text-primary-500">{views}</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -22,7 +22,7 @@ const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProp
   const isInDetailPage = location.pathname.startsWith('/community/') && location.pathname !== '/community/emotion' && location.pathname !== '/community/question';
 
   const handleClick = () => {
-    if (!isInDetailPage) navigate(`/community/${id}`);
+      if (!isInDetailPage) navigate(`/community/${post.type}/${post.id}`);
   };
 
   if (viewType === 'list') {

--- a/src/components/community/PostDetail.tsx
+++ b/src/components/community/PostDetail.tsx
@@ -11,9 +11,9 @@ import PostMoreButton from './PostMoreButton';
 import CommunityTitle from './CommunityTitle';
 
 const PostDetail = () => {
-  const { id } = useParams();
+  const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
-  const post = dummyPosts.find(p => p.id === id);
+  const post = dummyPosts.find(p => p.id === postId);
 
   if (!post) return <div>게시글을 찾을 수 없습니다.</div>;
 

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -3,20 +3,21 @@ import { Post } from '@/types/Post';
 
 interface PostListProps {
   posts: Post[];
-  onClickPost?: (postId: string) => void;
+  viewType: 'grid' | 'list';
 }
 
-const PostList = ({ posts, onClickPost }: PostListProps) => {
+const PostList = ({ posts, viewType }: PostListProps) => {
   if (posts.length === 0) {
-    return <p className="text-center text-gray-500">게시글이 없습니다.</p>;
+    return <p className="text-center text-[16px] text-gray-600 pt-10">게시글이 없습니다.</p>;
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
       {posts.map((post) => (
         <PostCard
           key={post.id}
           post={post}
+          viewType={viewType}
           onLikeToggle={() => {}}
           onCommentClick={() => {}}
         />

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -11,8 +11,13 @@ const PostList = ({ posts, viewType }: PostListProps) => {
     return <p className="text-center text-[16px] text-gray-600 pt-10">게시글이 없습니다.</p>;
   }
 
+  const isGrid = viewType === 'grid';
+  const containerClass = isGrid
+    ? 'grid grid-cols-1 gap-4'
+    : 'flex flex-col gap-3';
+
   return (
-    <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
+    <div className={containerClass}>
       {posts.map((post) => (
         <PostCard
           key={post.id}

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -1,0 +1,28 @@
+import PostCard from './PostCard';
+import { Post } from '@/types/Post';
+
+interface PostListProps {
+  posts: Post[];
+  onClickPost?: (postId: string) => void;
+}
+
+const PostList = ({ posts, onClickPost }: PostListProps) => {
+  if (posts.length === 0) {
+    return <p className="text-center text-gray-500">게시글이 없습니다.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {posts.map((post) => (
+        <PostCard
+          key={post.id}
+          post={post}
+          onLikeToggle={() => {}}
+          onCommentClick={() => {}}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default PostList;

--- a/src/components/community/ViewToggleButton.tsx
+++ b/src/components/community/ViewToggleButton.tsx
@@ -1,0 +1,33 @@
+import { LayoutList, TvMinimal } from 'lucide-react';
+import IconWrapper from './IconWrapper';
+
+interface ViewToggleButtonProps {
+  viewType: 'grid' | 'list';
+  onChange: (view: 'grid' | 'list') => void;
+}
+
+const ViewToggleButton = ({ viewType, onChange }: ViewToggleButtonProps) => {
+  return (
+    <div className="flex items-center gap-[7px]">
+      <IconWrapper
+        icon={TvMinimal}
+        size={24}
+        color={viewType === 'grid' ? '#343C6A' : '#9C9FB4'}
+        onClick={() => onChange('grid')}
+        ariaLabel="피드 뷰로 보기"
+        className="hover:bg-gray-100 rounded p-1"
+      />
+      <span className="w-px h-[12px] bg-gray-400"></span>
+      <IconWrapper
+        icon={LayoutList}
+        size={24}
+        color={viewType === 'list' ? '#343C6A' : '#9C9FB4'}
+        onClick={() => onChange('list')}
+        ariaLabel="리스트 뷰로 보기"
+        className="hover:bg-gray-100 rounded p-1"
+      />
+    </div>
+  );
+};
+
+export default ViewToggleButton;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -72,7 +72,7 @@ const Sidebar = ({ isVisible, toggleSidebar }: { isVisible: boolean; toggleSideb
                 <NavItem to="/community/question" icon={MessageCircleMore} text="질문 게시판" />
               </li>
               <li>
-                <NavItem to="/community/emotional-consumption" icon={MessageCircleHeart} text="감정 소비 이야기" />
+                <NavItem to="/community/emotion" icon={MessageCircleHeart} text="감정 소비 이야기" />
               </li>
               <li>
                 <NavItem to="/community/notice" icon={Volume2} text="공지사항" />

--- a/src/pages/Community/CommunityList.tsx
+++ b/src/pages/Community/CommunityList.tsx
@@ -3,11 +3,12 @@ import { useParams } from 'react-router-dom';
 import CommunityTitle from '@/components/community/CommunityTitle';
 import CommunityNewPostButton from '@/components/community/CommunityNewPostButton';
 import ViewToggleButton from '@/components/community/ViewToggleButton';
-import PostCard from '@/components/community/PostCard';
+import PostList from '@/components/community/PostList';
 import { dummyPosts } from '@/constants/dummyPosts';
+import { PostType } from '@/types/Post';
 
 const CommunityList = () => {
-  const { type } = useParams();
+  const { type } = useParams<{ type: PostType }>();
   const [viewType, setViewType] = useState<'grid' | 'list'>('grid');
   const [sortType, setSortType] = useState<'recent' | 'popular'>('recent');
 
@@ -30,6 +31,8 @@ const CommunityList = () => {
     }
     return '/community/write';
   };
+
+  const filteredPosts = dummyPosts.filter((post) => post.type === type);
 
   return (
     <div className="relative w-full max-w-[800px] mx-auto px-4 sm:px-6">
@@ -57,22 +60,12 @@ const CommunityList = () => {
       </div>
 
       {/* 게시글 목록 */}
-    <div className={viewType === 'grid' ? 'grid grid-cols-1 gap-3' : 'flex flex-col gap-5'}>
-        {dummyPosts.map((post) => (
-          <PostCard
-            key={post.id}
-            post={post}
-            viewType={viewType}
-            onLikeToggle={() => console.log('좋아요')}
-            onCommentClick={() => console.log('댓글')}
-          />
-        ))}
-      </div>
+      <PostList posts={filteredPosts} viewType={viewType} />
 
       {/* 글쓰기 버튼 */}
       {type !== 'notice' && type && (
         <div className="fixed bottom-8 right-8 z-50">
-          <CommunityNewPostButton to={getWritePageLink()} postType={type as 'emotion' | 'question' | 'notice'} />
+          <CommunityNewPostButton to={getWritePageLink()} postType={type} />
         </div>
       )}
     </div>

--- a/src/pages/Community/CommunityList.tsx
+++ b/src/pages/Community/CommunityList.tsx
@@ -1,9 +1,15 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import CommunityTitle from '@/components/community/CommunityTitle';
 import CommunityNewPostButton from '@/components/community/CommunityNewPostButton';
+import ViewToggleButton from '@/components/community/ViewToggleButton';
+import PostCard from '@/components/community/PostCard';
+import { dummyPosts } from '@/constants/dummyPosts';
 
 const CommunityList = () => {
   const { type } = useParams();
+  const [viewType, setViewType] = useState<'grid' | 'list'>('grid');
+  const [sortType, setSortType] = useState<'recent' | 'popular'>('recent');
 
   const getBoardTitle = () => {
     switch (type) {
@@ -20,7 +26,7 @@ const CommunityList = () => {
 
   const getWritePageLink = () => {
     if (type === 'notice') {
-      return '/community/notice/write'; // (혹시 필요 없으면 /community/write로 통일)
+      return '/community/notice/write';
     }
     return '/community/write';
   };
@@ -29,10 +35,42 @@ const CommunityList = () => {
     <div className="relative w-full max-w-[800px] mx-auto px-4 sm:px-6">
       <CommunityTitle title={getBoardTitle()} />
 
-      {/* 게시글 목록 map 영역 */}
+      {/* 정렬 및 뷰토글 */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2 text-sm text-primary-500">
+          <button
+            className={`${sortType === 'recent' ? 'font-semibold text-primary-800' : ''}`}
+            onClick={() => setSortType('recent')}
+          >
+            최신순
+          </button>
+          <span className="text-gray-400">·</span>
+          <button
+            className={`${sortType === 'popular' ? 'font-semibold text-primary-800' : ''}`}
+            onClick={() => setSortType('popular')}
+          >
+            인기순
+          </button>
+        </div>
 
-      {/* 글쓰기 플로팅 버튼 */}
-      {type !== 'notice' && type && ( // notice 아니고, type 존재할 때만 노출
+        <ViewToggleButton viewType={viewType} onChange={setViewType} />
+      </div>
+
+      {/* 게시글 목록 */}
+    <div className={viewType === 'grid' ? 'grid grid-cols-1 gap-3' : 'flex flex-col gap-5'}>
+        {dummyPosts.map((post) => (
+          <PostCard
+            key={post.id}
+            post={post}
+            viewType={viewType}
+            onLikeToggle={() => console.log('좋아요')}
+            onCommentClick={() => console.log('댓글')}
+          />
+        ))}
+      </div>
+
+      {/* 글쓰기 버튼 */}
+      {type !== 'notice' && type && (
         <div className="fixed bottom-8 right-8 z-50">
           <CommunityNewPostButton to={getWritePageLink()} postType={type as 'emotion' | 'question' | 'notice'} />
         </div>

--- a/src/pages/Community/CommunityList.tsx
+++ b/src/pages/Community/CommunityList.tsx
@@ -1,0 +1,44 @@
+import { useParams } from 'react-router-dom';
+import CommunityTitle from '@/components/community/CommunityTitle';
+import CommunityNewPostButton from '@/components/community/CommunityNewPostButton';
+
+const CommunityList = () => {
+  const { type } = useParams();
+
+  const getBoardTitle = () => {
+    switch (type) {
+      case 'question':
+        return '질문 게시판';
+      case 'emotion':
+        return '감정 소비 이야기';
+      case 'notice':
+        return '공지사항';
+      default:
+        return '알 수 없는 게시판';
+    }
+  };
+
+  const getWritePageLink = () => {
+    if (type === 'notice') {
+      return '/community/notice/write'; // (혹시 필요 없으면 /community/write로 통일)
+    }
+    return '/community/write';
+  };
+
+  return (
+    <div className="relative w-full max-w-[800px] mx-auto px-4 sm:px-6">
+      <CommunityTitle title={getBoardTitle()} />
+
+      {/* 게시글 목록 map 영역 */}
+
+      {/* 글쓰기 플로팅 버튼 */}
+      {type !== 'notice' && type && ( // notice 아니고, type 존재할 때만 노출
+        <div className="fixed bottom-8 right-8 z-50">
+          <CommunityNewPostButton to={getWritePageLink()} postType={type as 'emotion' | 'question' | 'notice'} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommunityList;

--- a/src/pages/Community/PostWrite.tsx
+++ b/src/pages/Community/PostWrite.tsx
@@ -2,25 +2,39 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button';
 import CommunityTitle from '@/components/community/CommunityTitle';
-import { Image } from 'lucide-react';
+import { Triangle } from 'lucide-react';
 import { Post } from '@/types/Post';
 
 const PostWrite = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const existingPost = location.state as Post | undefined; // 수정 모드인지 판단
+  const existingPost = location.state?.post as Post | undefined;
+  const initialType = location.state?.type as 'emotion' | 'question' | 'notice' | undefined; // 글쓰기 버튼에서 넘겨준 type
+
+  const isEdit = !!existingPost;
 
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [image, setImage] = useState<File | null>(null);
 
-  const isEdit = !!existingPost;
+  // 운영자 여부 (임시)
+  const isAdmin = false;
+
+  const [selectedCategory, setSelectedCategory] = useState<'emotion' | 'question' | 'notice'>(
+    initialType ?? existingPost?.type ?? 'question'
+  );
+
+  const categoryOptions = [
+    { value: 'question', label: '질문 게시판' },
+    { value: 'emotion', label: '감정 소비 이야기' },
+    ...(isAdmin ? [{ value: 'notice', label: '공지사항' }] : []),
+  ];
 
   useEffect(() => {
     if (isEdit && existingPost) {
       setTitle(existingPost.title);
       setContent(existingPost.content);
-      // 이미지 초기화는 제외 (API 연동 시 처리)
+      setSelectedCategory(existingPost.type as 'emotion' | 'question' | 'notice');
     }
   }, [isEdit, existingPost]);
 
@@ -33,46 +47,86 @@ const PostWrite = () => {
     const confirmed = window.confirm(`게시글을 ${isEdit ? '수정' : '등록'}하시겠습니까?`);
     if (!confirmed) return;
 
-    // 등록/수정 API 로직 작성 예정
-    // ...
+    if (selectedCategory === 'notice') {
+      console.log('공지사항 등록');
+    } else {
+      console.log('커뮤니티 게시글 등록');
+    }
 
-    // 완료 후 이동
-    navigate('/community/1'); // 추후 수정 필요 (예: 등록된 postId 활용)
+    switch (selectedCategory) {
+      case 'question':
+        navigate('/community/question');
+        break;
+      case 'emotion':
+        navigate('/community/emotion');
+        break;
+      case 'notice':
+        navigate('/community/notice');
+        break;
+      default:
+        navigate('/community');
+    }
   };
 
   return (
-    <div className="w-full max-w-[800px] mx-auto px-4 sm:px-6 py-8">
-      <CommunityTitle title="감정 소비 이야기" />
+    <div className="flex-1 p-5 lg:p-10">
+      <div className="relative w-full max-w-[800px] mx-auto px-4 sm:px-6">
+        <CommunityTitle title="게시글 작성" />
 
-      <div className="border bg-white rounded-lg p-6 shadow-sm">
-        <input
-          type="text"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          placeholder="제목을 입력해주세요."
-          className="w-full text-xl font-medium placeholder:text-gray-400 mb-4 focus:outline-none border-b pb-2"
-        />
+        <div className="border bg-white rounded-lg p-6 shadow-sm">
+          {/* 카테고리 드롭다운 */}
+          <div className="mb-4">
+            <div className="relative inline-block w-full">
+              <select
+                value={selectedCategory}
+                onChange={(e) => setSelectedCategory(e.target.value as 'emotion' | 'question' | 'notice')}
+                className="appearance-none w-full text-lg font-semibold text-primary-800 border-b-2 border-primary-800 bg-transparent focus:outline-none pl-2 pr-8 py-2"
+              >
+                {categoryOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <Triangle
+                size={14}
+                className="absolute right-2 top-1/2 transform -translate-y-1/2 text-primary-800 pointer-events-none rotate-180 fill-current"
+              />
+            </div>
+          </div>
 
-        <textarea
-          value={content}
-          onChange={e => setContent(e.target.value)}
-          placeholder="콘텐츠 내용을 입력하세요."
-          className="w-full min-h-[200px] placeholder:text-gray-400 text-sm focus:outline-none border-b pb-4 resize-none"
-        />
+          {/* 제목 입력 */}
+          <input
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="제목을 입력해주세요."
+            className="w-full text-xl font-medium placeholder:text-gray-400 mb-4 focus:outline-none border-b pb-2"
+          />
 
-        <div className="flex items-center justify-between mt-4 text-sm text-gray-400 pb-3">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <Image size={16} />
-            <span>사진 {image ? '1/1' : '0/1'}</span>
-            <input type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
-          </label>
+          {/* 내용 입력 */}
+          <textarea
+            value={content}
+            onChange={e => setContent(e.target.value)}
+            placeholder="콘텐츠 내용을 입력하세요."
+            className="w-full min-h-[200px] placeholder:text-gray-400 text-sm focus:outline-none border-b pb-4 resize-none"
+          />
+
+          {/* 이미지 업로드 */}
+          <div className="flex items-center justify-between mt-4 text-sm text-gray-400 pb-3">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <span>사진 {image ? '1/1' : '0/1'}</span>
+              <input type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
+            </label>
+          </div>
         </div>
-      </div>
 
-      <div className="mt-6">
-        <Button width="w-full" onClick={handleSubmit}>
-          {isEdit ? '수정' : '등록'}
-        </Button>
+        {/* 등록/수정 버튼 */}
+        <div className="mt-6">
+          <Button width="w-full" onClick={handleSubmit}>
+            {isEdit ? '수정' : '등록'}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -11,7 +11,7 @@ export interface Author {
 // 게시글 데이터 구조 정의
 export interface Post {
   id: string; // 게시글 고유 ID
-  type: string; // 게시글 유형
+  type: PostType; // 게시글 유형
   title: string; // 제목
   content: string; // 본문 내용
   imageUrl?: string; // 첨부 이미지 URL (선택)
@@ -23,6 +23,7 @@ export interface Post {
   comments?: number; // 댓글
   views?: number; // 조회
 }
+
 // 댓글 데이터 구조 정의
 export interface Comment {
   id: string; // 댓글 고유 ID


### PR DESCRIPTION
## 변경 사항
- 게시판 타입별 제목, 설명 등 분기 처리
- 게시글 리스트 UI 레이아웃 구성 및 컴포넌트 구현 (PostCard 기반)
- 최신순/인기순 정렬 탭 UI 구현
- 피드뷰 / 리스트뷰 전환 버튼 UI 구현 및 뷰 모드 전환 기능 동작 처리

### 스크린샷
![image](https://github.com/user-attachments/assets/d270ce97-52ff-4ee8-9fb9-a2665fcf4b61)
![image](https://github.com/user-attachments/assets/8e75d54b-68dd-492d-9feb-2613784275b6)
![image](https://github.com/user-attachments/assets/57c035a1-36df-4118-91eb-a28153c64155)
![image](https://github.com/user-attachments/assets/19784425-dd0c-406a-8444-c3f928d6d8e0)





## 반영 브랜치
- 예: feature/#38-community-list-ui → develop

## 관련 이슈
- Closes #38 

## 참고 사항
- 테스트용 dummy 데이터 기반으로 구현
### 아래 항목은 별도 이슈로 관리 예정
- 무한스크롤 기능 구현
- 정렬 기능 구현
- 실제 API 연동 및 게시글 데이터 바인딩
- 공지사항 게시글의 상단 고정(핀) UI 구현
