### PR TITLE
Feature/#50 community post pin UI

### DIFF
--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { format } from 'date-fns';
-import { Eye } from 'lucide-react';
+import { Eye, Pin } from 'lucide-react'; // ★ 여기 Pin 추가
 import { PostCardProps } from '@/types/Post';
 import LikeButton from './LikeButton';
 import CommentButton from './CommentButton';
@@ -16,7 +16,7 @@ interface ExtendedProps extends PostCardProps {
 const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProps) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { id, title, imageUrl, content, createdAt, likes, comments, views, author } = post;
+  const { title, imageUrl, content, createdAt, likes, comments, views, author, isPinned } = post;
   const formattedDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
 
   const isInDetailPage =
@@ -81,7 +81,24 @@ const PostCard = ({ post, viewType, onLikeToggle, onCommentClick }: ExtendedProp
       </div>
 
       {/* 제목 */}
-      <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+      <div className="flex items-center justify-between">
+        <h2
+          className={`text-lg font-semibold ${
+            post.type === 'notice' ? 'text-accent-red' : 'text-gray-800'
+          }`}
+        >
+          {title}
+        </h2>
+        {isPinned && (
+          <IconWrapper
+            icon={Pin}
+            size={20}
+            fill="#151d4a"
+            color="#151d4a"
+            className="rotate-45"
+          />
+        )}
+      </div>
 
       {/* 이미지 */}
       {imageUrl && (

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -1,25 +1,47 @@
 import PostCard from './PostCard';
-import { Post } from '@/types/Post';
+import { Post, PostType } from '@/types/Post';
 
 interface PostListProps {
   posts: Post[];
   viewType: 'grid' | 'list';
+  boardType: PostType;
 }
 
-const PostList = ({ posts, viewType }: PostListProps) => {
+const PostList = ({ posts, viewType, boardType }: PostListProps) => {
   if (posts.length === 0) {
     return <p className="text-center text-[16px] text-gray-600 pt-10">게시글이 없습니다.</p>;
   }
 
-  const pinnedPosts = posts.filter(post => post.isPinned);
-  const normalPosts = posts.filter(post => !post.isPinned);
+  // 최신순으로 정렬
+  const sortedPosts = [...posts].sort((a, b) => {
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
 
-  return (
-    <>
-      {/* 고정글 먼저 출력 */}
-      {pinnedPosts.length > 0 && (
-        <div className="mb-6">
-          {pinnedPosts.map(post => (
+  // notice 게시판일 경우 고정글/일반글 분리
+  if (boardType === 'notice') {
+    const pinnedPosts = sortedPosts.filter(post => post.isPinned);
+    const normalPosts = sortedPosts.filter(post => !post.isPinned);
+
+    return (
+      <>
+        {/* 고정글 출력 */}
+        {pinnedPosts.length > 0 && (
+          <div className="mb-6">
+            {pinnedPosts.map(post => (
+              <PostCard
+                key={post.id}
+                post={post}
+                viewType={viewType}
+                onLikeToggle={() => {}}
+                onCommentClick={() => {}}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* 일반글 출력 */}
+        <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
+          {normalPosts.map(post => (
             <PostCard
               key={post.id}
               post={post}
@@ -29,21 +51,23 @@ const PostList = ({ posts, viewType }: PostListProps) => {
             />
           ))}
         </div>
-      )}
+      </>
+    );
+  }
 
-      {/* 일반 게시글 출력 */}
-      <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
-        {normalPosts.map(post => (
-          <PostCard
-            key={post.id}
-            post={post}
-            viewType={viewType}
-            onLikeToggle={() => {}}
-            onCommentClick={() => {}}
-          />
-        ))}
-      </div>
-    </>
+  // 다른 게시판은 그냥 출력
+  return (
+    <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
+      {sortedPosts.map(post => (
+        <PostCard
+          key={post.id}
+          post={post}
+          viewType={viewType}
+          onLikeToggle={() => {}}
+          onCommentClick={() => {}}
+        />
+      ))}
+    </div>
   );
 };
 

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -12,15 +12,10 @@ const PostList = ({ posts, viewType, boardType }: PostListProps) => {
     return <p className="text-center text-[16px] text-gray-600 pt-10">게시글이 없습니다.</p>;
   }
 
-  // 최신순으로 정렬
-  const sortedPosts = [...posts].sort((a, b) => {
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-  });
-
-  // notice 게시판일 경우 고정글/일반글 분리
+  // 공지사항이면 고정글/일반글 분리해서 출력
   if (boardType === 'notice') {
-    const pinnedPosts = sortedPosts.filter(post => post.isPinned);
-    const normalPosts = sortedPosts.filter(post => !post.isPinned);
+    const pinnedPosts = posts.filter(post => post.isPinned);
+    const normalPosts = posts.filter(post => !post.isPinned);
 
     return (
       <>
@@ -58,7 +53,7 @@ const PostList = ({ posts, viewType, boardType }: PostListProps) => {
   // 다른 게시판은 그냥 출력
   return (
     <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
-      {sortedPosts.map(post => (
+      {posts.map(post => (
         <PostCard
           key={post.id}
           post={post}

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -11,23 +11,39 @@ const PostList = ({ posts, viewType }: PostListProps) => {
     return <p className="text-center text-[16px] text-gray-600 pt-10">게시글이 없습니다.</p>;
   }
 
-  const isGrid = viewType === 'grid';
-  const containerClass = isGrid
-    ? 'grid grid-cols-1 gap-4'
-    : 'flex flex-col gap-3';
+  const pinnedPosts = posts.filter(post => post.isPinned);
+  const normalPosts = posts.filter(post => !post.isPinned);
 
   return (
-    <div className={containerClass}>
-      {posts.map((post) => (
-        <PostCard
-          key={post.id}
-          post={post}
-          viewType={viewType}
-          onLikeToggle={() => {}}
-          onCommentClick={() => {}}
-        />
-      ))}
-    </div>
+    <>
+      {/* 고정글 먼저 출력 */}
+      {pinnedPosts.length > 0 && (
+        <div className="mb-6">
+          {pinnedPosts.map(post => (
+            <PostCard
+              key={post.id}
+              post={post}
+              viewType={viewType}
+              onLikeToggle={() => {}}
+              onCommentClick={() => {}}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* 일반 게시글 출력 */}
+      <div className={`grid ${viewType === 'grid' ? 'grid-cols-1 gap-2' : 'flex flex-col gap-6'}`}>
+        {normalPosts.map(post => (
+          <PostCard
+            key={post.id}
+            post={post}
+            viewType={viewType}
+            onLikeToggle={() => {}}
+            onCommentClick={() => {}}
+          />
+        ))}
+      </div>
+    </>
   );
 };
 

--- a/src/constants/dummyPosts.ts
+++ b/src/constants/dummyPosts.ts
@@ -18,6 +18,23 @@ export const dummyPosts: Post[] = [
     views: 300,
     isPinned: true,
   },
+    {
+    id: '999',
+    type: 'notice',
+    title: '새 기능 업데이트 안내',
+    content: '신규 기능이 추가되었습니다. 확인 부탁드립니다.',
+    createdAt: '2025-04-26T10:00:00',
+    updatedAt: '2025-04-26T10:00:00',
+    author: {
+      id: 'admin',
+      nickname: '운영자',
+    },
+    isMine: true,
+    likes: 8,
+    comments: 3,
+    views: 250,
+    isPinned: false,
+  },
   {
     id: '1',
     type: 'emotion',

--- a/src/constants/dummyPosts.ts
+++ b/src/constants/dummyPosts.ts
@@ -1,6 +1,23 @@
 import { Post } from '../types/Post';
 
 export const dummyPosts: Post[] = [
+    {
+    id: '999',
+    type: 'notice',
+    title: '서비스 점검 안내',
+    content: '서비스 점검이 예정되어 있습니다. 불편을 드려 죄송합니다.',
+    createdAt: '2025-04-25T08:00:00',
+    updatedAt: '2025-04-25T08:00:00',
+    author: {
+      id: 'admin',
+      nickname: '운영자',
+    },
+    isMine: true,
+    likes: 10,
+    comments: 5,
+    views: 300,
+    isPinned: true,
+  },
   {
     id: '1',
     type: 'emotion',

--- a/src/pages/Community/CommunityList.tsx
+++ b/src/pages/Community/CommunityList.tsx
@@ -32,7 +32,17 @@ const CommunityList = () => {
     return '/community/write';
   };
 
+  // 현재 게시판 타입에 맞는 글만 필터링
   const filteredPosts = dummyPosts.filter((post) => post.type === type);
+
+  // 최신순 정렬
+  const sortedPosts = [...filteredPosts].sort((a, b) => {
+    if (sortType === 'recent') {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    } else {
+      return (b.likes ?? 0) - (a.likes ?? 0);
+    }
+  });
 
   return (
     <div className="relative w-full max-w-[800px] mx-auto px-4 sm:px-6">
@@ -60,7 +70,13 @@ const CommunityList = () => {
       </div>
 
       {/* 게시글 목록 */}
-      <PostList posts={filteredPosts} viewType={viewType} />
+      {type && (
+        <PostList
+          posts={sortedPosts}
+          viewType={viewType}
+          boardType={type}
+        />
+      )}
 
       {/* 글쓰기 버튼 */}
       {type !== 'notice' && type && (

--- a/src/pages/Community/CommunityList.tsx
+++ b/src/pages/Community/CommunityList.tsx
@@ -32,17 +32,28 @@ const CommunityList = () => {
     return '/community/write';
   };
 
-  // 현재 게시판 타입에 맞는 글만 필터링
+  // 게시판 타입별 게시글 필터링
   const filteredPosts = dummyPosts.filter((post) => post.type === type);
 
-  // 최신순 정렬
-  const sortedPosts = [...filteredPosts].sort((a, b) => {
+  // 고정글과 일반글 분리 (공지사항만 해당)
+  const pinnedPosts = type === 'notice' ? filteredPosts.filter(post => post.isPinned) : [];
+  const normalPosts = type === 'notice' ? filteredPosts.filter(post => !post.isPinned) : filteredPosts;
+
+  // 일반글 정렬
+  const sortedNormalPosts = [...normalPosts].sort((a, b) => {
     if (sortType === 'recent') {
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    } else {
-      return (b.likes ?? 0) - (a.likes ?? 0);
     }
+    if (sortType === 'popular') {
+      const aLikes = typeof a.likes === 'number' ? a.likes : 0;
+      const bLikes = typeof b.likes === 'number' ? b.likes : 0;
+      return bLikes - aLikes;
+    }
+    return 0;
   });
+
+  // 고정글 + 일반글 병합한 최종 리스트
+  const finalPosts = [...pinnedPosts, ...sortedNormalPosts];
 
   return (
     <div className="relative w-full max-w-[800px] mx-auto px-4 sm:px-6">
@@ -72,7 +83,7 @@ const CommunityList = () => {
       {/* 게시글 목록 */}
       {type && (
         <PostList
-          posts={sortedPosts}
+          posts={finalPosts}
           viewType={viewType}
           boardType={type}
         />

--- a/src/pages/Community/PostWrite.tsx
+++ b/src/pages/Community/PostWrite.tsx
@@ -47,12 +47,29 @@ const PostWrite = () => {
     const confirmed = window.confirm(`게시글을 ${isEdit ? '수정' : '등록'}하시겠습니까?`);
     if (!confirmed) return;
 
-    if (selectedCategory === 'notice') {
-      console.log('공지사항 등록');
-    } else {
-      console.log('커뮤니티 게시글 등록');
-    }
+    // 이미지 URL 가상 생성
+    const imageUrl = image ? URL.createObjectURL(image) : undefined;
 
+    // 저장할 Post 객체 생성
+    const newPost: Post = {
+      id: `${Date.now()}`, // 임시 ID
+      type: selectedCategory,
+      title,
+      content,
+      imageUrl, // 이미지 URL 반영
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      author: { id: 'currentUser', nickname: '나' }, // 임시 작성자
+      isMine: true,
+      likes: 0,
+      comments: 0,
+      views: 0,
+      isPinned: selectedCategory === 'notice' ? true : false, // 기본 고정글 여부
+    };
+
+    console.log('작성된 게시글 데이터:', newPost);
+
+    // 작성 완료 후 해당 게시판으로 이동
     switch (selectedCategory) {
       case 'question':
         navigate('/community/question');
@@ -99,7 +116,7 @@ const PostWrite = () => {
           <input
             type="text"
             value={title}
-            onChange={e => setTitle(e.target.value)}
+            onChange={(e) => setTitle(e.target.value)}
             placeholder="제목을 입력해주세요."
             className="w-full text-xl font-medium placeholder:text-gray-400 mb-4 focus:outline-none border-b pb-2"
           />
@@ -107,7 +124,7 @@ const PostWrite = () => {
           {/* 내용 입력 */}
           <textarea
             value={content}
-            onChange={e => setContent(e.target.value)}
+            onChange={(e) => setContent(e.target.value)}
             placeholder="콘텐츠 내용을 입력하세요."
             className="w-full min-h-[200px] placeholder:text-gray-400 text-sm focus:outline-none border-b pb-4 resize-none"
           />

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -22,6 +22,7 @@ export interface Post {
   likes?: number; // 좋아요
   comments?: number; // 댓글
   views?: number; // 조회
+  isPinned?: boolean; // 고정글 여부
 }
 
 // 댓글 데이터 구조 정의


### PR DESCRIPTION
## 변경 사항
- 커뮤니티 게시판 고정글/일반글 분리 출력 로직 추가 (공지사항 타입만 적용)
- 커뮤니티 게시판 최신순/인기순 정렬 로직 추가
- 커뮤니티 게시글 저장 시 객체 생성 로직 추가 및 이미지 첨부 시 URL 생성하여 Post 객체에 반영
- 작성 완료 후 해당 게시판으로 자동 이동 처리

### 스크린샷
![image](https://github.com/user-attachments/assets/8d399504-afd6-4ba2-b678-db995a3022c4)
![image](https://github.com/user-attachments/assets/ea288c31-8822-4424-a256-8215c5c2dc02)
![image](https://github.com/user-attachments/assets/dbe5e3c1-6bf5-4204-b643-baf67db5a10e)
![image](https://github.com/user-attachments/assets/6a78ed11-f04a-40b4-92e1-0239359d2141)
![image](https://github.com/user-attachments/assets/48878c68-fc1d-47f0-b187-86348ee1658a)

## 반영 브랜치
- feature/#50-community-post-pin-ui → develop

## 관련 이슈
- Closes #50

## 참고 사항
- 현재 작성 및 저장 되는 게시글은 dummy 데이터 기준으로 관리 및 console에 저장
- API 연동은 댓글/대댓글 기능 추가 후 순차적으로 진행 예정