### PR TITLE
[Style] #69 유저 관련 페이지 (로그인, 회원가입, 마이페이지, 비밀번호 등) 반응형 구현

### DIFF
--- a/src/components/common/DropdownInput.tsx
+++ b/src/components/common/DropdownInput.tsx
@@ -31,7 +31,7 @@ const DropdownInput = <T extends string>({ items, selected, style, placeholder, 
   }, []);
 
   return (
-    <div ref={ref} className={clsx("relative inline-block mb-4", className || 'w-[500px]')}>
+    <div ref={ref} className={clsx("relative inline-block mb-4", className || 'w-full')}>
       <div
         className={`flex items-center h-[60px] px-3 py-2 text-sm cursor-pointer ${getWrapperClass(style)}`}
         onClick={() => setIsOpen(prev => !prev)}

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -27,7 +27,7 @@ const Input: React.FC<InputProps> = ({
   const inputId = `input-${label?.toLowerCase().replace(/\s+/g, '-') || Math.random().toString(36).substring(2, 9)}`;
 
   return (
-    <div className="mb-4">
+    <div className="mb-4 w-full">
       {label && (
         <label htmlFor={inputId} className="block text-sm font-medium mb-1">
           {label} {required && <span className="text-red-500">*</span>}
@@ -36,7 +36,7 @@ const Input: React.FC<InputProps> = ({
       <input
         id={inputId}
         type={type}
-        className={`border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none ${error ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : ''} ${className}`}
+        className={`border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none w-full ${error ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : ''} ${className}`}
         value={value}
         placeholder={placeholder}
         onChange={onChange}

--- a/src/components/common/InputWithCheckbox.tsx
+++ b/src/components/common/InputWithCheckbox.tsx
@@ -66,7 +66,7 @@ const InputWithCheckButton = ({
           className="flex-1 px-4 py-3 text-sm text-gray-900 placeholder-gray-500 focus:outline-none"
         />
         <Button
-          className="mr-2 font-normal"
+          className="mr-1 font-normal"
           width="w-[80px]"
           height="h-[35px]"
           fontSize="small"

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,0 +1,9 @@
+import logo from '@/assets/logo.png';
+
+const Logo = () => {
+  return (
+    <img className="w-[150px] sm:w-[290px] my-4 sm:my-10" src={logo}/>
+  )
+}
+
+export default Logo;

--- a/src/components/common/Modal/BaseModal.tsx
+++ b/src/components/common/Modal/BaseModal.tsx
@@ -31,7 +31,7 @@ const BaseModal = ({ isOpen, onClose, children }: BaseModalProps) => {
 
       {/* 모달 콘텐츠 */}
       <div
-        className="modal-wrapper relative bg-white rounded-2xl shadow-xl w-[620px] p-[60px] pt-[150px]"
+        className="modal-wrapper relative bg-white rounded-2xl shadow-xl w-[350px] sm:w-[620px] p-4 sm:p-[60px] pt-[50px] sm:pt-[150px]"
         onClick={e => e.stopPropagation()} // 모달 내부 클릭은 닫히지 않게 막기
       >
         <CloseButton onClick={onClose} />

--- a/src/pages/ChangePassword/ChangePasswordModal.tsx
+++ b/src/pages/ChangePassword/ChangePasswordModal.tsx
@@ -31,8 +31,8 @@ const ChangePasswordModal = ({ isOpen, onClose }: Props) => {
   return (
     <>
       <BlankModal isOpen={isOpen} onClose={handleClose}>
-        <div className="flex flex-col justify-center items-center w-[500px]">
-          <h2 className='text-2xl font-semibold mb-10'>비밀번호 변경</h2>
+        <div className="flex flex-col justify-center items-center w-[300px] sm:w-[500px]">
+          <h2 className='text-xl sm:text-2xl font-semibold mb-10'>비밀번호 변경</h2>
           <ChangePasswordForm onSubmit={handleChangePassword} />
         </div>
       </BlankModal>

--- a/src/pages/ChangePassword/components/ChangePasswordForm.tsx
+++ b/src/pages/ChangePassword/components/ChangePasswordForm.tsx
@@ -42,10 +42,10 @@ const ChangePasswordForm = ({ onSubmit }: Props) => {
   }
 
   return (
-    <form className="flex flex-col items-center gap-4 w-full mb-10" >
-      <p className='text-gray-600 '>현재 비밀번호 입력</p>
+    <form className="flex flex-col items-center justify-center gap-4 w-full mb-10" >
+      <p className='text-gray-600'>현재 비밀번호 입력</p>
       <Input 
-        className='h-[60px] w-[500px]'
+        className='h-[60px] w-full'
         type='password'
         value={currentPassword}
         placeholder='현재 비밀번호를 입력해주세요.'
@@ -59,7 +59,7 @@ const ChangePasswordForm = ({ onSubmit }: Props) => {
         error={passwordError}
       />
       {error && <p className="text-sm text-accent-red my-1">{error}</p>}
-      <Button type="button" width="w-[500px]" onClick={handleSubmit}>
+      <Button type="button" width="w-full" onClick={handleSubmit}>
         비밀번호 변경하기
       </Button>
       

--- a/src/pages/FindPassword/FindPasswordPage.tsx
+++ b/src/pages/FindPassword/FindPasswordPage.tsx
@@ -1,17 +1,17 @@
-import logo from '@/assets/logo.png';
 import FindPasswordForm from './components/FindPasswordForm';
 import { useState } from 'react';
 import ChangePasswordModal from '../ChangePassword/ChangePasswordModal';
+import Logo from '@/components/common/Logo';
 
 const FindPasswordPage = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div className="flex flex-col items-center h-full min-h-screen bg-gray-200">
-      <div className="my-10 flex flex-col items-center min-w-[700px] border-b-2 border-gr">
-        <img className="w-[290px] my-10" src={logo}/>
-        <h2 className='text-center font-semibold text-3xl'>비밀번호 찾기</h2>
-        <p className='my-8 text-center text-gray-800 text-xl'>가입 시 등록한 정보를 입력해 주세요. <br/>
+      <div className="my-10 flex flex-col items-center w-[350px] sm:min-w-[700px] border-b-2 border-gr">
+        <Logo />
+        <h2 className='text-center font-semibold text-xl sm:text-3xl'>비밀번호 찾기</h2>
+        <p className='my-8 text-center text-gray-800 text-sm sm:text-xl'>가입 시 등록한 정보를 입력해 주세요. <br/>
         입력하신 정보를 확인한 후, 비밀번호 재설정 안내를 드립니다.</p>
       </div>
       <div className="felx felx-col h-full justify-center">

--- a/src/pages/FindPassword/components/FindPasswordForm.tsx
+++ b/src/pages/FindPassword/components/FindPasswordForm.tsx
@@ -6,7 +6,7 @@ import SecurityQuestion from '@/pages/Signup/components/SecurityQuestion';
 import { isValidEmail } from '@/utils/validators';
 import { useState } from 'react';
 
-const FindPasswordForm = ({onVerified} : {onVerified : () => void}) => {
+const FindPasswordForm = ({ onVerified }: { onVerified: () => void }) => {
   const [email, setEmail] = useState('');
   const [question, setQuestion] = useState('');
   const [answer, setAnswer] = useState('');
@@ -30,19 +30,18 @@ const FindPasswordForm = ({onVerified} : {onVerified : () => void}) => {
       setFormError('모든 필드를 입력해주세요.');
       return;
     }
-    // TODO 서버에 검증 요청
     try {
-      await findPassword({email, question, answer});
+      await findPassword({ email, question, answer });
       onVerified();
     } catch (err) {
       console.log('본인 확인 싶패', err);
-      setFormError('등록된 회원 정보를 찾을 수 없습니다.')
+      setFormError('등록된 회원 정보를 찾을 수 없습니다.');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-[500px]">
-      <Input className="w-full h-[60px]" placeholder="이메일" value={email} onChange={handleEmailChange} />
+    <form onSubmit={handleSubmit} className="w-[300px] sm:w-[500px]">
+      <Input className="h-[60px]" placeholder="이메일" value={email} onChange={handleEmailChange} />
       {emailError && <p className="text-sm text-accent-red">{emailError}</p>}
       {/* 본인확인용 질문 */}
       <SecurityQuestion

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,7 +1,7 @@
-import logo from '@/assets/logo.png';
 import Welcome from '@/assets/images/welcome.png';
 import LoginForm from './components/LoginForm';
 import { Link } from 'react-router-dom';
+import Logo from '@/components/common/Logo';
 
 const LoginPage = () => {
   return (
@@ -9,12 +9,12 @@ const LoginPage = () => {
       <div className="flex justify-center items-center h-screen gap-20">
         {/* 왼쪽 로그인 영역 */}
         <div className='flex flex-col gap-4 text-center items-center'>
-          <div className='mb-20'>
-            <h2 className='text-4xl'>감정 가계부</h2>
-            <img className='w-[290px]' src={logo} />
+          <div className='mb-5 sm:mb-20'>
+            <h2 className='text-xl sm:text-4xl'>감정 가계부</h2>
+            <Logo />
           </div>
           <LoginForm />
-          <div className='flex gap-3 w-[500px] my-4 text-gray-600'>
+          <div className='flex gap-3 w-[300px] sm:w-[500px] my-4 text-gray-600'>
                 <p>회원이 아니신가요?</p>
                 <Link to='/signup' className='underline'>회원가입</Link>
                 <Link to='/find-password' className='underline'>비밀번호 찾기</Link>

--- a/src/pages/Signup/SignupPage.tsx
+++ b/src/pages/Signup/SignupPage.tsx
@@ -1,12 +1,12 @@
-import logo from '@/assets/logo.png';
+import Logo from '@/components/common/Logo';
 import SignupForm from './components/SignupForm';
 
 const SignupPage = () => {
   return (
     <div className="flex flex-col items-center h-full min-h-screen bg-gray-200">
-      <div className="my-10">
-        <img className="w-[290px] my-10" src={logo}/>
-        <h2 className='text-center font-semibold text-3xl'>회원가입</h2>
+      <div className="my-4 sm:my-10">
+        <Logo />
+        <h2 className='text-center font-semibold text-xl sm:text-3xl'>회원가입</h2>
       </div>
       <div className="felx felx-col h-full justify-center">
         <SignupForm />

--- a/src/pages/Signup/components/PasswordConfirm.tsx
+++ b/src/pages/Signup/components/PasswordConfirm.tsx
@@ -8,7 +8,7 @@ interface PasswordConfirmProps {
 }
 const PasswordConfirm = ({ password, passwordConfirm, onChange, error }: PasswordConfirmProps) => {
   return (
-    <div className='w-[500px]'>
+    <div className='w-full'>
       <Input
         placeholder="비밀번호"
         type="password"

--- a/src/pages/Signup/components/SecurityQuestion.tsx
+++ b/src/pages/Signup/components/SecurityQuestion.tsx
@@ -10,7 +10,7 @@ interface SecurityQuestionProps {
 
 const SecurityQuestion = ({questions, question, answer, onChange} : SecurityQuestionProps) => {
   return (
-    <div className="mt-6">
+    <div className="mt-6 w-full">
       <p className="font-semibold text-primary-900 mb-2">본인확인용 질문</p>
       <DropdownInput
         items={questions}

--- a/src/pages/Signup/components/SignupForm.tsx
+++ b/src/pages/Signup/components/SignupForm.tsx
@@ -100,7 +100,7 @@ const SignupForm = () => {
 
   return (
     <>
-      <form className="w-[500px] mb-20" onSubmit={handleSubmit}>
+      <form className='w-[300px] sm:w-[500px] mb-20' onSubmit={handleSubmit}>
         {/* 이름 */}
         <Input placeholder="이름" value={userInfo.name} onChange={handleChange('name')} className="h-[60px] w-full" />
 

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -30,7 +30,7 @@ const MyPage = () => {
     <>
       <MainLayout>
         <div className="flex flex-col min-h-screen items-center">
-          <div>
+          <div className='w-[320px] sm:w-[500px]'>
             <h2 className="text-2xl font-bold mb-6">내정보</h2>
             {!myProfile ? (
               <div className="flex justify-center items-center">
@@ -39,7 +39,7 @@ const MyPage = () => {
             ) : (
               <InformationCard nickname={myProfile.nickname} email={myProfile.email} role={myProfile.role} />
             )}
-            <div className="flex gap-4">
+            <div className="flex flex-wrap gap-4 my-4">
               <PostCard title="내가 작성한 글" icon={<UserPen />} count={myPosts.length} link="/" />
               <PostCard title="좋아요 표시한 글" icon={<BookHeart />} count={myPosts.length} link="/" />
             </div>

--- a/src/pages/myPage/components/PostsCard.tsx
+++ b/src/pages/myPage/components/PostsCard.tsx
@@ -10,7 +10,7 @@ interface PostCardProps {
 const PostCard = ({title, icon, count, link} : PostCardProps) => {
 
   return (
-  <div className="bg-white rounded-md w-60 p-4 my-4">
+  <div className="bg-white rounded-md w-full sm:w-60 p-4">
     <h3>{title}</h3>
     <div className="flex justify-between items-center my-2">
       <span className="text-accent-blue text-2xl font-semibold">{count}</span>

--- a/src/pages/myPage/components/userMenu/ConfirmModal.tsx
+++ b/src/pages/myPage/components/userMenu/ConfirmModal.tsx
@@ -4,29 +4,34 @@ import AlertModal from '@/components/common/Modal/AlertModal';
 import { useConfirmWithdraw } from '@/hooks/auth/useConfirmWithdraw';
 import { Lock } from 'lucide-react';
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const ConfirmModal = ({ onConfirm }: { onConfirm: () => void }) => {
   const [password, setPassword] = useState('');
   const { confirmWithdraw, loading, error } = useConfirmWithdraw();
   const [isAlertOpen, setIsAlertOpen] = useState(false);
 
+  const navigate = useNavigate();
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const success = await confirmWithdraw(password);
     if (success) {
       onConfirm();
       setIsAlertOpen(true);
+      navigate('/');
     }
   };
 
   return (
-    <div className="flex justify-center w-[500px] flex-col items-center text-center mb-10">
+    <div className="flex justify-center w-[300px] sm:w-[500px] flex-col items-center text-center mb-10">
       <Lock size={60} color="#2D60FF" />
-      <h2 className="text-xl text-gray-800 mt-[34px]">본인 확인을 위해 비밀번호를 입력해주세요.</h2>
-      <div className="min-h-[20px] mt-[14px] text-accent-red">
-        탈퇴 후 30일 이내에 같은 계정으로 해당 서비스에 가입할 수 없습니다.
-        </div>
-      <form className="flex flex-col w-[500px] my-8" onSubmit={handleSubmit}>
+      <h2 className="text-xl text-gray-800 mt-[34px] flex flex-wrap justify-center">
+        본인 확인을 위해<br className="sm:hidden" /> 비밀번호를 입력해주세요.
+      </h2>
+      <div className="min-h-[20px] mt-[14px] text-accent-red flex flex-wrap justify-center">
+        탈퇴 후 30일 이내에 같은 계정으로<br className="sm:hidden" />해당 서비스에 가입할 수 없습니다.
+      </div>
+      <form className="flex flex-col w-full my-8" onSubmit={handleSubmit}>
         <Input
           className="w-full h-[60px]"
           value={password}


### PR DESCRIPTION
## 변경 사항
- 유저 관련 페이지 (로그인, 회원가입, 마이페이지, 비밀번호 등) 반응형 구현

## 반영 브랜치
- feature/#69-login-ui → develop

## 관련 이슈
- close #69 

## 참고 사항
- 리뷰어가 참고할만한 내용이 있다면 적어주세요.
![image](https://github.com/user-attachments/assets/71073259-a3d4-48e0-91ec-ab01d8cf708d)
![image](https://github.com/user-attachments/assets/5cb7b8cb-70b6-42f7-a829-b23e8458fd19)
![image](https://github.com/user-attachments/assets/9077209d-8632-45ff-a01a-09a68de121ce)
